### PR TITLE
entryAt uses nil as the default value, fixes find and select-keys

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -225,9 +225,8 @@
 
   (entryAt
     [this k]
-    (let [v (.valAt this k this)]
-      (when-not (identical? this v)
-        (clojure.lang.MapEntry. k v))))
+    (when-some [v (.valAt this k)]
+      (clojure.lang.MapEntry. k v)))
 
   (seq
     [this]


### PR DESCRIPTION
To address #3 -

```clojure
(require '[envoy.core :as env :refer [defenv env]])

(defenv :a-boolean
  "A boolean field"
  :type :boolean)

(select-keys env [:a-boolean])
;; => {}
(env/set-env! :a-boolean false)
;; => nil
(select-keys env [:a-boolean])
;; => {:a-boolean false}
```