### PR TITLE
:parser defenv attribute for custom var parsing

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -20,6 +20,7 @@
    :line number?
    :description string?
    :type types/value-types
+   :parser fn?
    :missing check/behavior-types})
 
 
@@ -113,10 +114,12 @@
   ; Look up variable definition.
   (if-let [definition (get known-vars k)]
     (if (some? v)
-      ; Parse the string value for known types.
-      (if-let [type-key (:type definition)]
-        (types/parse type-key v)
-        v)
+      ; Parse the string value with custom parser or for known types.
+      (or (when-let [parser (:parser definition)]
+            (parser v))
+          (when-let [type-key (:type definition)]
+            (types/parse type-key v))
+          v)
       ; Check if the var has missing behavior.
       (behave! :missing-access (:missing definition)
                "Access to env variable %s which has no value" k))

--- a/test/envoy/core_test.clj
+++ b/test/envoy/core_test.clj
@@ -23,15 +23,6 @@
   "Specifying a special parsing fn."
   :parser clojure.edn/read-string)
 
-(ns envoy.core-test.special)
-(def parser clojure.string/lower-case)
-
-(ns envoy.core-test)
-
-(defenv :envoy-custom-ns-parser
-  "Specifying a special parsing fn."
-  :parser envoy.core-test.special/parser)
-
 
 (deftest env-declaration
   (is (contains? env/known-vars :envoy-test))
@@ -45,7 +36,4 @@
     (is (= {:a 1} (env/env :envoy-custom-parser))))
   (do
     (env/set-env! :envoy-custom-parser "{:a {:b [\"1\" 2.0 \\3 \" \"]}}")
-    (is (= {:a {:b ["1" 2.0 \3 " "]}} (env/env :envoy-custom-parser))))
-  (do
-    (env/set-env! :envoy-custom-ns-parser "APascalCase")
-    (is (= "apascalcase" (env/env :envoy-custom-ns-parser)))))
+    (is (= {:a {:b ["1" 2.0 \3 " "]}} (env/env :envoy-custom-parser)))))

--- a/test/envoy/core_test.clj
+++ b/test/envoy/core_test.clj
@@ -19,9 +19,33 @@
 (defenv :envoy-bad-type
   "Re-declaring a variable.")
 
+(defenv :envoy-custom-parser
+  "Specifying a special parsing fn."
+  :parser clojure.edn/read-string)
+
+(ns envoy.core-test.special)
+(def parser clojure.string/lower-case)
+
+(ns envoy.core-test)
+
+(defenv :envoy-custom-ns-parser
+  "Specifying a special parsing fn."
+  :parser envoy.core-test.special/parser)
+
 
 (deftest env-declaration
   (is (contains? env/known-vars :envoy-test))
   (is (= "Test environment variable." (get-in env/known-vars [:envoy-test :description])))
   (is (= :integer (get-in env/known-vars [:envoy-test :type])))
   (is (= 'envoy.core-test (get-in env/known-vars [:envoy-test :ns]))))
+
+(deftest parser-declaration
+  (do
+    (env/set-env! :envoy-custom-parser "{:a 1}")
+    (is (= {:a 1} (env/env :envoy-custom-parser))))
+  (do
+    (env/set-env! :envoy-custom-parser "{:a {:b [\"1\" 2.0 \\3 \" \"]}}")
+    (is (= {:a {:b ["1" 2.0 \3 " "]}} (env/env :envoy-custom-parser))))
+  (do
+    (env/set-env! :envoy-custom-ns-parser "APascalCase")
+    (is (= "apascalcase" (env/env :envoy-custom-ns-parser)))))


### PR DESCRIPTION
Using new :parser override instead of adding a `:type` of `:edn` since that's not generally advisable and letting a custom parser is more extensible.