### PR TITLE
Change duplicate environment variable log level from error to warning

### DIFF
--- a/src/envoy/core.clj
+++ b/src/envoy/core.clj
@@ -67,8 +67,10 @@
   ; Check for previous declarations.
   (when-let [extant (get known-vars env-key)]
     (when (not= (:ns extant) (:ns properties))
-      (log/errorf "Environment variable definition for %s at %s is overriding existing definition from %s"
-                  env-key (declared-location properties) (declared-location extant))))
+      (log/warnf "Environment variable definition for %s at %s is overriding existing definition from %s"
+                 env-key
+                 (declared-location properties)
+                 (declared-location extant))))
   ; Check property schemas.
   (doseq [prop-key (keys properties)]
     (validate-attr! env-key prop-key properties))


### PR DESCRIPTION
WARN seems more appropriate to how this is used in practice.